### PR TITLE
Add date tracking and CSV export

### DIFF
--- a/src/models/TimeEntry.ts
+++ b/src/models/TimeEntry.ts
@@ -1,4 +1,5 @@
 export interface TimeEntry {
+  date: string;
   start: string;
   end: string;
   project: string;

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -1,5 +1,6 @@
 import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
 import { TimeTrackingPlugin } from './main';
+import { calculateDiffInMinutes, formatMinutesAsHM } from './utils/time';
 
 export class TimeTrackingSettingTab extends PluginSettingTab {
   constructor(public app: App, private plugin: TimeTrackingPlugin) {
@@ -31,6 +32,101 @@ export class TimeTrackingSettingTab extends PluginSettingTab {
           await this.plugin.saveSettings();
           new Notice('Runden von Zeiten auf 15 Minuten ist jetzt ' + (value ? 'aktiviert' : 'deaktiviert') + '.');
         })
+      );
+
+    containerEl.createEl('h3', { text: 'Berichte' });
+
+    let monthVal = '';
+    let projectVal = '';
+
+    new Setting(containerEl)
+      .setName('Monat')
+      .addText(text => {
+        text.inputEl.type = 'month';
+        text.onChange(value => {
+          monthVal = value;
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Projekt')
+      .addText(text => {
+        text.onChange(value => {
+          projectVal = value;
+        });
+      });
+
+    new Setting(containerEl)
+      .addButton(btn =>
+        btn
+          .setButtonText('Monat auswerten')
+          .onClick(() => {
+            if (!monthVal) {
+              new Notice('Bitte Monat auswählen');
+              return;
+            }
+            const [y, m] = monthVal.split('-');
+            const start = `${y}-${m}-01`;
+            const end = new Date(Number(y), Number(m), 0)
+              .toISOString()
+              .slice(0, 10);
+            const entries = this.plugin.filterEntries(start, end, projectVal || undefined);
+            const total = entries.reduce(
+              (acc, e) =>
+                acc +
+                calculateDiffInMinutes(
+                  e.start,
+                  e.end,
+                  this.plugin.settings.roundTimesToQuarterHour
+                ),
+              0
+            );
+            new Notice('Gesamtstunden: ' + formatMinutesAsHM(total));
+          })
+      );
+
+    containerEl.createEl('h4', { text: 'CSV Export' });
+    let exportStart = '';
+    let exportEnd = '';
+    let exportProject = '';
+
+    new Setting(containerEl)
+      .setName('Zeitraum')
+      .addText(text => {
+        text.inputEl.type = 'date';
+        text.onChange(value => {
+          exportStart = value;
+        });
+      })
+      .addText(text => {
+        text.inputEl.type = 'date';
+        text.onChange(value => {
+          exportEnd = value;
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Projektfilter')
+      .addText(text => {
+        text.onChange(value => {
+          exportProject = value;
+        });
+      });
+
+    new Setting(containerEl)
+      .addButton(btn =>
+        btn
+          .setButtonText('CSV exportieren')
+          .onClick(async () => {
+            if (!exportStart || !exportEnd) {
+              new Notice('Bitte Zeitraum wählen');
+              return;
+            }
+            const csv = this.plugin.generateCsv(exportStart, exportEnd, exportProject || undefined);
+            const fileName = `time-export-${exportStart}-bis-${exportEnd}.csv`;
+            await this.app.vault.create(fileName, csv);
+            new Notice('CSV exportiert: ' + fileName);
+          })
       );
   }
 }

--- a/src/ui/TimeTrackerBlock.ts
+++ b/src/ui/TimeTrackerBlock.ts
@@ -49,7 +49,7 @@ export class TimeTrackerBlock extends MarkdownRenderChild {
 
     this.tableEl = this.container.createEl('table', { cls: 'time-tracker-table' });
     const headerRow = this.tableEl.createEl('tr');
-    ['Startzeit', 'Endzeit', 'Stunden', 'Projekt', 'Tätigkeit', 'Aktion'].forEach(h =>
+    ['Datum', 'Startzeit', 'Endzeit', 'Stunden', 'Projekt', 'Tätigkeit', 'Aktion'].forEach(h =>
       headerRow.createEl('th', { text: h })
     );
 
@@ -57,7 +57,7 @@ export class TimeTrackerBlock extends MarkdownRenderChild {
     this.renderTableRows();
 
     this.sumRow = this.tableEl.createEl('tr', { cls: 'sum-row' });
-    const sumLabelCell = this.sumRow.createEl('td', { attr: { colspan: '2' } });
+    const sumLabelCell = this.sumRow.createEl('td', { attr: { colspan: '3' } });
     sumLabelCell.setText('Gesamt-Summe');
     const sumHoursCell = this.sumRow.createEl('td', { cls: 'sum-hours' });
     sumHoursCell.setText(this.calculateSumAll());
@@ -74,7 +74,7 @@ export class TimeTrackerBlock extends MarkdownRenderChild {
 
     const addButton = this.container.createEl('button', { text: 'Zeile hinzufügen' });
     addButton.onclick = () => {
-      this.plugin.data.instances[this.trackerId].push({ start: '', end: '', project: '', activity: '' });
+      this.plugin.data.instances[this.trackerId].push({ date: new Date().toISOString().slice(0, 10), start: '', end: '', project: '', activity: '' });
       this.plugin.savePluginData();
       this.renderTableRows();
       this.updateAllSums();
@@ -99,6 +99,15 @@ export class TimeTrackerBlock extends MarkdownRenderChild {
 
   private createRow(entry: TimeEntry): void {
     const row = this.tbody.insertRow(-1);
+
+    const dateCell = row.insertCell(-1);
+    const dateInput = dateCell.createEl('input');
+    dateInput.type = 'date';
+    dateInput.value = entry.date;
+    dateInput.addEventListener('change', () => {
+      entry.date = dateInput.value;
+      this.plugin.savePluginData();
+    });
 
     const startCell = row.insertCell(-1);
     const startInput = startCell.createEl('input');
@@ -167,7 +176,7 @@ export class TimeTrackerBlock extends MarkdownRenderChild {
   }
 
   private updateRow(row: HTMLTableRowElement, entry: TimeEntry): void {
-    const hoursCell = row.cells[2];
+    const hoursCell = row.cells[3];
     hoursCell.textContent = this.calculateTime(entry.start, entry.end);
   }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -35,3 +35,11 @@ export function calculateDiffInMinutes(start: string, end: string, round?: boole
   }
   return diff;
 }
+
+export function isDateInRange(date: string, start: string, end: string): boolean {
+  if (!date) return false;
+  const d = new Date(date);
+  const s = new Date(start);
+  const e = new Date(end);
+  return d >= s && d <= e;
+}


### PR DESCRIPTION
## Summary
- add `date` field to `TimeEntry`
- store default date when loading legacy data
- extend time tracker table with date column and inputs
- allow CSV export and monthly reporting in settings
- provide helper functions to filter and export entries

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian')*
