### PR TITLE
Add project list management

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,9 +1,13 @@
 export interface TimeTrackingPluginSettings {
   autoCleanup: boolean;
   roundTimesToQuarterHour: boolean;
+  projects: string[];
+  migratedProjects?: boolean;
 }
 
 export const DEFAULT_SETTINGS: TimeTrackingPluginSettings = {
   autoCleanup: false,
   roundTimesToQuarterHour: false,
+  projects: [],
+  migratedProjects: false,
 };

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -34,6 +34,37 @@ export class TimeTrackingSettingTab extends PluginSettingTab {
         })
       );
 
+    containerEl.createEl('h3', { text: 'Projekte' });
+    const projectsContainer = containerEl.createDiv();
+    const renderProjects = () => {
+      projectsContainer.empty();
+      this.plugin.settings.projects.forEach((proj, index) => {
+        new Setting(projectsContainer)
+          .addText(text => {
+            text.setValue(proj);
+            text.onChange(value => {
+              this.plugin.settings.projects[index] = value;
+              void this.plugin.saveSettings();
+            });
+          })
+          .addButton(btn =>
+            btn.setButtonText('Entfernen').onClick(() => {
+              this.plugin.settings.projects.splice(index, 1);
+              renderProjects();
+              void this.plugin.saveSettings();
+            })
+          );
+      });
+      new Setting(projectsContainer).addButton(btn =>
+        btn.setButtonText('Projekt hinzufügen').onClick(() => {
+          this.plugin.settings.projects.push('');
+          renderProjects();
+          void this.plugin.saveSettings();
+        })
+      );
+    };
+    renderProjects();
+
     containerEl.createEl('h3', { text: 'Berichte' });
 
     let monthVal = '';

--- a/src/ui/TimeTrackerBlock.ts
+++ b/src/ui/TimeTrackerBlock.ts
@@ -139,11 +139,14 @@ export class TimeTrackerBlock extends MarkdownRenderChild {
     hoursCell.textContent = this.calculateTime(entry.start, entry.end);
 
     const projectCell = row.insertCell(-1);
-    const projectInput = projectCell.createEl('input');
-    projectInput.type = 'text';
-    projectInput.value = entry.project;
-    projectInput.addEventListener('change', () => {
-      entry.project = projectInput.value;
+    const projectSelect = projectCell.createEl('select');
+    projectSelect.createEl('option', { value: '', text: '' });
+    this.plugin.settings.projects.forEach(p => {
+      projectSelect.createEl('option', { value: p, text: p });
+    });
+    projectSelect.value = entry.project;
+    projectSelect.addEventListener('change', () => {
+      entry.project = projectSelect.value;
       this.plugin.savePluginData();
       if (this.plugin.data.sortSettings[this.trackerId] === 'project') {
         this.renderTableRows();


### PR DESCRIPTION
## Summary
- keep list of projects in plugin settings
- migrate existing project names once
- use dropdown for project selection

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian')*